### PR TITLE
Add progressive click multiplier

### DIFF
--- a/index.html
+++ b/index.html
@@ -180,6 +180,10 @@
   function zoneCost(L){ return 150 * Math.pow(L, 1.35); }
   function clickBase(L){ return 1.0 * Math.pow(L, 0.9); }
   function upgradeCost(lvl){ return 50 * Math.pow(lvl, 1.15); }
+  function clickMultiplier(lvl){
+    const capped = Math.min(lvl, 500);
+    return Math.pow(1.013, capped - 1);
+  }
 
   // UI refresh (Farm)
   function refreshFarm(){
@@ -255,7 +259,7 @@
 
   // Game logic
   function addEnergy(){
-    const gain = (clickBase(state.zone) * (1 + state.clickLevel*0.15)) * state.prestigeMult;
+    const gain = (clickBase(state.zone) * clickMultiplier(state.clickLevel)) * state.prestigeMult;
     state.energy += gain;
     $('#energy').textContent = fmt(state.energy);
   }


### PR DESCRIPTION
## Summary
- add clickMultiplier utility applying 1.3% progressive growth capped at 500 levels
- apply new multiplier to energy gain per click

## Testing
- `node -e "function clickMultiplier(lvl){const capped=Math.min(lvl,500);return Math.pow(1.013,capped-1);} console.log(clickMultiplier(1), clickMultiplier(2), clickMultiplier(500), clickMultiplier(501));"`


------
https://chatgpt.com/codex/tasks/task_e_689f7d68294c832da06f6353e8d95a79