### PR TITLE
Add passive income loop and reset controls

### DIFF
--- a/index.html
+++ b/index.html
@@ -51,7 +51,13 @@
 </head>
 <body>
   <header>
-    <h1>EVA: After-H Clicker — Prototype (offline) + Carte du Monde</h1>
+    <div class="row" style="justify-content:space-between; align-items:center;">
+      <h1 style="margin:0">EVA: After-H Clicker — Prototype (offline) + Carte du Monde</h1>
+      <div class="row" style="gap:8px;">
+        <button class="btn" id="resetSave">Réinitialiser la sauvegarde</button>
+        <span class="tiny">Sauvegarde auto & locale</span>
+      </div>
+    </div>
   </header>
 
   <nav class="tabs">
@@ -71,6 +77,7 @@
               <span class="stat">Evacoins: <b id="evacoins">0</b></span>
               <span class="stat">Points: <b id="points">0</b></span>
               <span class="stat">Prestige x<b id="prestigeMult">1.00</b></span>
+              <span class="stat">Passif: <b id="passiveRate">0</b>/s</span>
             </div>
             <span class="pill">Zone <b id="zone">1</b></span>
           </div>
@@ -157,6 +164,7 @@
     zone: 1, clickLevel: 1, prestigeMult: 1,
     totalSpentPoints: 0, pityLegendary: 0, pityHolo: 0,
     inventory: [],
+    passiveLevel: 1,
     // Monde
     biomes: [
       {id:1, name:'Laboratoire (Scientifiques)', start:1, end:10},
@@ -176,10 +184,17 @@
   const fmt = n => Math.floor(n).toLocaleString('fr-FR');
   function save(){ localStorage.setItem('eva_clicker_proto_v2', JSON.stringify(state)); }
   function load(){ try { Object.assign(state, JSON.parse(localStorage.getItem('eva_clicker_proto_v2')||'{}')); } catch{} }
+  function ensureDefaults(){
+    if(!state.passiveLevel) state.passiveLevel = 1;
+  }
 
   function zoneCost(L){ return 150 * Math.pow(L, 1.35); }
   function clickBase(L){ return 1.0 * Math.pow(L, 0.9); }
   function upgradeCost(lvl){ return 50 * Math.pow(lvl, 1.15); }
+  function passiveRate(){
+    const base = Math.max(1, state.zone * 0.4);
+    return parseFloat((base * state.passiveLevel * state.prestigeMult).toFixed(2));
+  }
 
   // UI refresh (Farm)
   function refreshFarm(){
@@ -189,6 +204,7 @@
     $('#points').textContent = fmt(state.points);
     $('#zone').textContent = state.zone;
     $('#prestigeMult').textContent = state.prestigeMult.toFixed(2);
+    $('#passiveRate').textContent = passiveRate().toFixed(2);
     $('#zoneCost').textContent = fmt(zoneCost(state.zone));
     $('#upgradeCost').textContent = fmt(upgradeCost(state.clickLevel));
     $('#accountStats').innerHTML = `Niveau de clic: <b>${state.clickLevel}</b><br/>Points dépensés: <b>${fmt(state.totalSpentPoints)}</b><br/>Pity L: <b>${state.pityLegendary}</b> — Pity H: <b>${state.pityHolo}</b>`;
@@ -297,6 +313,27 @@
     refreshFarm(); save(); worldProgress();
   }
 
+  function resetSave(){
+    if(!confirm('Réinitialiser la sauvegarde ?')) return;
+    localStorage.removeItem('eva_clicker_proto_v2');
+    Object.assign(state, {
+      energy:0, credits:0, evacoins:0, points:0,
+      zone:1, clickLevel:1, prestigeMult:1,
+      totalSpentPoints:0, pityLegendary:0, pityHolo:0,
+      inventory:[], passiveLevel:1
+    });
+    log('Nouvelle partie créée.');
+    refreshFarm(); worldProgress(); save();
+  }
+
+  function loopTick(){
+    state.energy += passiveRate();
+    $('#energy').textContent = fmt(state.energy);
+  }
+
+  // auto save
+  setInterval(()=>{ save(); }, 10_000);
+
   // Bindings
   $('#clickBtn').addEventListener('click', addEnergy);
   $('#sellEnergy').addEventListener('click', ()=>{ if(state.energy>=100){ state.energy-=100; state.credits+=100; refreshFarm(); save(); }});
@@ -307,6 +344,7 @@
   $('#buyStandard').addEventListener('click', ()=> buyPack('standard'));
   $('#buyPremium').addEventListener('click', ()=> buyPack('premium'));
   $('#doPrestige').addEventListener('click', prestige);
+  $('#resetSave').addEventListener('click', resetSave);
 
   // Tabs
   document.querySelectorAll('.tab').forEach(t=>{
@@ -322,8 +360,12 @@
   });
 
   // init
-  load(); refreshFarm(); worldProgress();
+  load(); ensureDefaults(); refreshFarm(); worldProgress();
   log('Bienvenue ! Clique pour collecter, vends pour des crédits, échange Evacoins → Points, achète des packs, avance de zone, et regarde la progression sur la carte du Monde.');
+  log('Gain passif actif pour démarrer plus vite — pense à sauvegarder ou utiliser le bouton Reset pour recommencer.');
+
+  // boucles
+  setInterval(loopTick, 1000);
 })();
 </script>
 </body>


### PR DESCRIPTION
## Summary
- add header controls for resetting the save and clarifying auto-save behavior
- display passive income rate and introduce a passive gain loop to jumpstart early progress
- keep saves healthy with default hydration and periodic autosave

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691f42411054832d9bc92110780b46d4)